### PR TITLE
Hotfix/v1.0.2 add backport pipeline

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -3,7 +3,7 @@ name: 🔁 Backport on merge to main
 on:
   push:
     branches: 
-      - feature/add-ci-cd-pipeline
+      - hotfix/v1.0.2-add-backport-pipeline
   pull_request:
     types: [closed]
     branches:

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -91,7 +91,7 @@ jobs:
 
             OUTPUT=$(npx backport \
               --accessToken "$GITHUB_TOKEN" \
-              --repo Crispelinho/coreplatform-price-api \
+              --repo Crispelinho/coreplatform-price-services \
               --pr "$PR_NUMBER" \
               --branch "$branch" \
               --commitConflicts true \

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -70,7 +70,7 @@ jobs:
         run: |
           PR_NUMBER="${{ github.event.pull_request.number }}"
           if [ -z "$PR_NUMBER" ]; then
-            PR_NUMBER=2
+            PR_NUMBER=5
           fi
 
           RELEASE_BRANCHES="${{ steps.release_branches.outputs.branches }}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All significant changes to this project will be documented in this file.
 
+## [1.0.2] - 2025-05-30
+
+### Changed
+
+- Updated backport workflow to trigger on `hotfix/v1.0.2-add-backport-pipeline` branch.
+- Fixed repository reference in backport workflow to use `coreplatform-price-services`.
+- Set default PR number to 5 in backport workflow for testing purposes.
+
 ## [1.0.1] - 2025-05-29
 
 ### Added


### PR DESCRIPTION
# **_Hotfix v1.0.2 - Add Backport Pipeline Trigger_**

This hotfix updates the backport workflow to correctly trigger the hotfix/v1.0.2-add-backport-pipeline branch. It ensures that recent updates to this branch automatically initiate the backport process.

## **_✅ 📷 Test Evidence_**

The workflow successfully detected the appropriate release/* branches and performed backports to all of them, including develop.

📋 Logs:
Backport executed against:

- develop
- release/v1.0.0
- release/v1.0.1

The logs are observed in the backports pipeline.

![image](https://github.com/user-attachments/assets/bda58c7a-4344-45af-bbe0-6af43501c15d)

Backport performed against the development branch and the release branches.

Backport PRs created:

[To develop](https://github.com/Crispelinho/coreplatform-price-services/pull/8)

[To release/v1.0.0](https://github.com/Crispelinho/coreplatform-price-services/pull/9)

[To release/v1.0.1](https://github.com/Crispelinho/coreplatform-price-services/pull/10)

![image](https://github.com/user-attachments/assets/c3e8a8a1-7715-47cc-b8ee-f288c45f0caa)

